### PR TITLE
feat: Issue #4 - POST /api/v1/auth/login ログインAPI実装

### DIFF
--- a/src/app/api/v1/auth/login/route.ts
+++ b/src/app/api/v1/auth/login/route.ts
@@ -1,0 +1,79 @@
+
+import {
+  successResponse,
+  unauthorizedError,
+  validationError,
+} from "@/lib/api-response";
+import { comparePassword, generateToken } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+import type { NextRequest } from "next/server";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const INVALID_CREDENTIALS_MSG =
+  "メールアドレスまたはパスワードが正しくありません";
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return validationError("リクエストボディが不正です");
+  }
+
+  const { email, password } = body as Record<string, unknown>;
+
+  // バリデーション
+  const details: { field: string; message: string }[] = [];
+
+  if (!email) {
+    details.push({ field: "email", message: "メールアドレスは必須です" });
+  } else if (typeof email !== "string" || !EMAIL_REGEX.test(email)) {
+    details.push({
+      field: "email",
+      message: "メールアドレスの形式で入力してください",
+    });
+  }
+
+  if (!password) {
+    details.push({ field: "password", message: "パスワードは必須です" });
+  }
+
+  if (details.length > 0) {
+    return validationError("入力値が不正です", details);
+  }
+
+  // 認証ロジック
+  const user = await prisma.user.findUnique({
+    where: { email: email as string },
+  });
+
+  if (!user || !user.isActive) {
+    return unauthorizedError(INVALID_CREDENTIALS_MSG);
+  }
+
+  const passwordMatch = await comparePassword(
+    password as string,
+    user.passwordHash,
+  );
+  if (!passwordMatch) {
+    return unauthorizedError(INVALID_CREDENTIALS_MSG);
+  }
+
+  const token = generateToken({
+    userId: user.id,
+    role: user.role,
+    name: user.name,
+  });
+
+  return successResponse({
+    token,
+    user: {
+      user_id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      department: user.department ?? undefined,
+    },
+  });
+}


### PR DESCRIPTION
## 概要

Issue #4 の実装。メールアドレス・パスワードで認証し JWT トークンを返す。

## 実装ファイル

- `src/app/api/v1/auth/login/route.ts`

## 実装内容

### バリデーション
- `email`: 必須・メール形式チェック → 400 `VALIDATION_ERROR`
- `password`: 必須 → 400 `VALIDATION_ERROR`

### 認証ロジック
1. `email` で DB 検索
2. ユーザー不在 または `is_active = false` → 401 `UNAUTHORIZED`
3. bcrypt でパスワード照合 → 不一致: 401 `UNAUTHORIZED`
4. JWT 生成（`{ userId, role, name }`、有効期限 24h）
5. 200 レスポンス: `{ data: { token, user: { user_id, name, email, role, department } } }`

> ユーザー列挙を防ぐため、ユーザー不在・パスワード不一致・無効ユーザーはすべて同一メッセージ「メールアドレスまたはパスワードが正しくありません」で返す。

## 受け入れ条件

テストは未実装（Issue #36 で対応予定）のため、動作確認はされていない。

- [ ] 正しい認証情報で 200 + token が返る
- [ ] 誤ったパスワードで 401 が返る
- [ ] 存在しないメールで 401 が返る
- [ ] `is_active = false` ユーザーで 401 が返る（AT-AUTH-001 #4）
- [ ] email 省略で 400 `VALIDATION_ERROR` が返る（AT-AUTH-001 #5）
- [ ] Authorization ヘッダーなしでアクセスできる

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)