### PR TITLE
feat: Issue #5 - POST /api/v1/auth/logout ログアウトAPI実装

### DIFF
--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+/**
+ * POST /api/v1/auth/logout
+ *
+ * JWT はステートレスなため、サーバー側での無効化は行わない。
+ * クライアントがトークンを破棄することでログアウトとする。
+ * 認証チェックは Middleware が担う（トークンなし → 401）。
+ */
+export function POST() {
+  return new NextResponse(null, { status: 204 });
+}


### PR DESCRIPTION
## 概要

Issue #5 の実装。有効なトークンで 204 を返す。

## 実装ファイル

- `src/app/api/v1/auth/logout/route.ts`

## 設計判断

JWT はステートレスなためサーバー側でのトークン無効化は行わない（Issue の「推奨」方針に従う）。クライアントがトークンを破棄することでログアウトとする。認証チェックは既存の Middleware が担うため、Route Handler は 204 を返すだけ。

## 受け入れ条件

テストは未実装（Issue #36 で対応予定）のため、動作確認はされていない。

- [ ] 有効なトークンで 204 が返る（AT-AUTH-002 #1）
- [ ] Authorization ヘッダーなしで 401 が返る（AT-AUTH-002 #2）

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)