### PR TITLE
feat: Issue #7 - POST /api/v1/reports 日報新規作成API

### DIFF
--- a/src/app/api/v1/reports/route.ts
+++ b/src/app/api/v1/reports/route.ts
@@ -117,8 +117,9 @@ export async function POST(request: NextRequest) {
 
   // 3. バリデーション
 
-  // report_date
-  const today = new Date().toISOString().slice(0, 10);
+  // report_date（ローカル時刻で今日の日付を取得）
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   if (report_date === undefined || report_date === null || report_date === "") {
     details.push({ field: "report_date", message: "日付は必須です" });
   } else if (

--- a/src/app/api/v1/reports/route.ts
+++ b/src/app/api/v1/reports/route.ts
@@ -1,5 +1,10 @@
 
-import { forbiddenError, successResponse } from "@/lib/api-response";
+import {
+  conflictError,
+  forbiddenError,
+  successResponse,
+  validationError,
+} from "@/lib/api-response";
 import { prisma } from "@/lib/prisma";
 import { requireRole } from "@/lib/require-role";
 
@@ -86,4 +91,201 @@ export async function GET(request: NextRequest) {
       total_pages: Math.ceil(total / perPage),
     },
   });
+}
+
+interface VisitRecordInput {
+  customer_id: unknown;
+  visit_content: unknown;
+  visit_order: unknown;
+}
+
+export async function POST(request: NextRequest) {
+  // 1. ロール検証: SALES のみ許可
+  const authUser = requireRole(request, ["SALES"]);
+  if (!authUser) return forbiddenError();
+
+  // 2. リクエストボディのパース
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return validationError("リクエストボディが不正です");
+  }
+
+  const { report_date, visit_records, problem, plan, status } = body;
+  const details: { field: string; message: string }[] = [];
+
+  // 3. バリデーション
+
+  // report_date
+  const today = new Date().toISOString().slice(0, 10);
+  if (report_date === undefined || report_date === null || report_date === "") {
+    details.push({ field: "report_date", message: "日付は必須です" });
+  } else if (
+    typeof report_date !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(report_date)
+  ) {
+    details.push({
+      field: "report_date",
+      message: "日付の形式が正しくありません（YYYY-MM-DD）",
+    });
+  } else if (report_date > today) {
+    details.push({
+      field: "report_date",
+      message: "今日以前の日付を指定してください",
+    });
+  }
+
+  // visit_records
+  if (!Array.isArray(visit_records) || visit_records.length === 0) {
+    details.push({
+      field: "visit_records",
+      message: "訪問記録は1件以上必要です",
+    });
+  } else {
+    (visit_records as VisitRecordInput[]).forEach((vr, i) => {
+      if (!vr.customer_id) {
+        details.push({
+          field: `visit_records[${i}].customer_id`,
+          message: "顧客IDは必須です",
+        });
+      }
+      if (!vr.visit_content) {
+        details.push({
+          field: `visit_records[${i}].visit_content`,
+          message: "訪問内容は必須です",
+        });
+      } else if (
+        typeof vr.visit_content === "string" &&
+        vr.visit_content.length > 1000
+      ) {
+        details.push({
+          field: `visit_records[${i}].visit_content`,
+          message: "訪問内容は1000文字以内で入力してください",
+        });
+      }
+    });
+  }
+
+  // problem
+  if (typeof problem === "string" && problem.length > 2000) {
+    details.push({
+      field: "problem",
+      message: "課題・相談は2000文字以内で入力してください",
+    });
+  }
+
+  // plan
+  if (typeof plan === "string" && plan.length > 2000) {
+    details.push({
+      field: "plan",
+      message: "明日やることは2000文字以内で入力してください",
+    });
+  }
+
+  // status
+  const statusValue = status ?? "DRAFT";
+  if (statusValue !== "DRAFT" && statusValue !== "SUBMITTED") {
+    details.push({
+      field: "status",
+      message: "ステータスは DRAFT または SUBMITTED を指定してください",
+    });
+  }
+
+  if (details.length > 0) {
+    return validationError("入力値が不正です", details);
+  }
+
+  // 4. 顧客の存在チェック（is_active = true のみ）
+  const visitRecordsInput = visit_records as VisitRecordInput[];
+  const customerIds = [
+    ...new Set(visitRecordsInput.map((vr) => Number(vr.customer_id))),
+  ];
+  const activeCustomers = await prisma.customer.findMany({
+    where: { id: { in: customerIds }, isActive: true },
+    select: { id: true },
+  });
+  const activeCustomerIds = new Set(activeCustomers.map((c) => c.id));
+  const invalidIds = customerIds.filter((id) => !activeCustomerIds.has(id));
+  if (invalidIds.length > 0) {
+    return validationError("入力値が不正です", [
+      {
+        field: "visit_records[].customer_id",
+        message: `顧客ID ${invalidIds.join(", ")} が存在しません`,
+      },
+    ]);
+  }
+
+  // 5. 同日付の重複チェック + トランザクションで日報・訪問記録を一括作成
+  const reportDate = new Date(report_date as string);
+
+  try {
+    const report = await prisma.$transaction(async (tx) => {
+      const existing = await tx.dailyReport.findUnique({
+        where: {
+          userId_reportDate: { userId: authUser.userId, reportDate },
+        },
+        select: { id: true },
+      });
+      if (existing) {
+        throw new Error("CONFLICT");
+      }
+
+      return tx.dailyReport.create({
+        data: {
+          userId: authUser.userId,
+          reportDate,
+          problem: typeof problem === "string" ? problem : null,
+          plan: typeof plan === "string" ? plan : null,
+          status: statusValue as "DRAFT" | "SUBMITTED",
+          visitRecords: {
+            create: visitRecordsInput.map((vr) => ({
+              customerId: Number(vr.customer_id),
+              visitContent: vr.visit_content as string,
+              visitOrder:
+                typeof vr.visit_order === "number" ? vr.visit_order : 1,
+            })),
+          },
+        },
+        include: {
+          user: { select: { id: true, name: true } },
+          visitRecords: {
+            include: {
+              customer: { select: { id: true, companyName: true } },
+            },
+            orderBy: { visitOrder: "asc" },
+          },
+        },
+      });
+    });
+
+    return successResponse(
+      {
+        report_id: report.id,
+        report_date: formatDate(report.reportDate),
+        status: report.status,
+        problem: report.problem,
+        plan: report.plan,
+        user: { user_id: report.user.id, name: report.user.name },
+        visit_records: report.visitRecords.map((vr) => ({
+          visit_id: vr.id,
+          customer: {
+            customer_id: vr.customer.id,
+            company_name: vr.customer.companyName,
+          },
+          visit_content: vr.visitContent,
+          visit_order: vr.visitOrder,
+        })),
+        comments: [],
+        created_at: report.createdAt.toISOString(),
+        updated_at: report.updatedAt.toISOString(),
+      },
+      201,
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === "CONFLICT") {
+      return conflictError(`${report_date as string} の日報は既に存在します`);
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

- `POST /api/v1/reports` エンドポイントを実装（`src/app/api/v1/reports/route.ts` に POST ハンドラ追加）
- SALES ロールのみ許可（MANAGER → 403）
- バリデーション: `report_date`（必須・今日以前・YYYY-MM-DD形式）、`visit_records`（1件以上・顧客存在確認・1000文字以内）、`problem`/`plan`（任意・2000文字以内）、`status`（DRAFT/SUBMITTED）
- 同日付の重複チェック → 409 CONFLICT
- `DailyReport` + `VisitRecord` をトランザクションで一括作成
- 201 レスポンスで日報詳細（`visit_records` 含む）を返す

## Test plan

- [ ] AT-REPORT-002 #1: 正常作成（DRAFT）→ 201
- [ ] AT-REPORT-002 #2: `status=SUBMITTED` で作成 → 201
- [ ] AT-REPORT-002 #3: 同日付の重複 → 409 CONFLICT
- [ ] AT-REPORT-002 #4: 存在しない `customer_id` → 400 VALIDATION_ERROR
- [ ] AT-REPORT-002 #5: MANAGER がアクセス → 403 FORBIDDEN
- [ ] UT-V-001 #3: `visit_records` が空配列 → 400
- [ ] UT-V-001 #4: `visit_content` 1001文字 → 400

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/claude-code)