### PR TITLE
feat: Issue #8 - GET /api/v1/reports/:id 日報詳細取得APIの実装

### DIFF
--- a/src/app/api/v1/reports/[reportId]/route.ts
+++ b/src/app/api/v1/reports/[reportId]/route.ts
@@ -1,0 +1,86 @@
+
+import {
+  forbiddenError,
+  notFoundError,
+  successResponse,
+} from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["SALES", "MANAGER"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const id = Number(reportId);
+  if (!Number.isInteger(id) || id <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id },
+    include: {
+      user: { select: { id: true, name: true, department: true } },
+      visitRecords: {
+        include: {
+          customer: { select: { id: true, companyName: true } },
+        },
+        orderBy: { visitOrder: "asc" },
+      },
+      comments: {
+        include: {
+          user: { select: { id: true, name: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  // SALES は自分の日報のみ
+  if (authUser.role === "SALES" && report.userId !== authUser.userId) {
+    return forbiddenError("この日報を閲覧する権限がありません");
+  }
+
+  return successResponse({
+    report_id: report.id,
+    report_date: formatDate(report.reportDate),
+    status: report.status,
+    problem: report.problem,
+    plan: report.plan,
+    user: {
+      user_id: report.user.id,
+      name: report.user.name,
+      department: report.user.department,
+    },
+    visit_records: report.visitRecords.map((vr) => ({
+      visit_id: vr.id,
+      customer: {
+        customer_id: vr.customer.id,
+        company_name: vr.customer.companyName,
+      },
+      visit_content: vr.visitContent,
+      visit_order: vr.visitOrder,
+    })),
+    comments: report.comments.map((c) => ({
+      comment_id: c.id,
+      comment_text: c.commentText,
+      user: { user_id: c.user.id, name: c.user.name },
+      created_at: c.createdAt.toISOString(),
+    })),
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  });
+}


### PR DESCRIPTION
## 概要

Closes #8

`GET /api/v1/reports/:report_id` エンドポイントを実装。

## 実装内容

- `src/app/api/v1/reports/[reportId]/route.ts` を新規作成
- 日報を `report_id` で検索し、存在しない場合は 404 を返す
- SALES ロールは自分の日報のみ取得可能（他者の日報は 403）
- MANAGER ロールは全員の日報を取得可能
- `visit_records` を `visit_order` 昇順で返す
- `comments` を `created_at` 昇順で返す
- 各レコードに関連データ（customer, user）を含める

## 受け入れ条件の確認

- [x] SALES が自分の日報を取得できる（AT-REPORT-003 #1）
- [x] SALES が他者の日報を取得しようとすると 403（AT-REPORT-003 #2）
- [x] MANAGER が任意の日報を取得できる（AT-REPORT-003 #3）
- [x] 存在しない ID で 404 が返る（AT-REPORT-003 #4）
- [x] visit_records が visit_order 昇順で返る

## テスト計画

- [x] `AT-REPORT-003 #1`: SALES ユーザーで自分の日報 ID を GET → 200 + 詳細レスポンス
- [x] `AT-REPORT-003 #2`: SALES ユーザーで他者の日報 ID を GET → 403 FORBIDDEN
- [x] `AT-REPORT-003 #3`: MANAGER ユーザーで任意の日報 ID を GET → 200 + 詳細レスポンス
- [x] `AT-REPORT-003 #4`: 存在しない ID で GET → 404 NOT_FOUND
- [x] visit_records の順序が visit_order 昇順であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)