### PR TITLE
[API] PUT /api/v1/reports/:id — 日報更新（F02）

### DIFF
--- a/src/app/api/v1/reports/[reportId]/route.ts
+++ b/src/app/api/v1/reports/[reportId]/route.ts
@@ -3,6 +3,7 @@ import {
   forbiddenError,
   notFoundError,
   successResponse,
+  validationError,
 } from "@/lib/api-response";
 import { prisma } from "@/lib/prisma";
 import { requireRole } from "@/lib/require-role";
@@ -82,5 +83,120 @@ export async function GET(
     })),
     created_at: report.createdAt.toISOString(),
     updated_at: report.updatedAt.toISOString(),
+  });
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["SALES"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const id = Number(reportId);
+  if (!Number.isInteger(id) || id <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id },
+    include: {
+      user: { select: { id: true, name: true, department: true } },
+      visitRecords: {
+        include: {
+          customer: { select: { id: true, companyName: true } },
+        },
+        orderBy: { visitOrder: "asc" },
+      },
+      comments: {
+        include: {
+          user: { select: { id: true, name: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  if (report.userId !== authUser.userId) {
+    return forbiddenError("この日報を編集する権限がありません");
+  }
+
+  if (report.status === "SUBMITTED") {
+    return forbiddenError("提出済みの日報は編集できません");
+  }
+
+  const body = (await request.json()) as { problem?: unknown; plan?: unknown };
+
+  const details: { field: string; message: string }[] = [];
+  if (body.problem !== undefined && body.problem !== null) {
+    if (typeof body.problem !== "string" || body.problem.length > 2000) {
+      details.push({ field: "problem", message: "2000文字以内で入力してください" });
+    }
+  }
+  if (body.plan !== undefined && body.plan !== null) {
+    if (typeof body.plan !== "string" || body.plan.length > 2000) {
+      details.push({ field: "plan", message: "2000文字以内で入力してください" });
+    }
+  }
+  if (details.length > 0) {
+    return validationError("入力値が不正です", details);
+  }
+
+  const updated = await prisma.dailyReport.update({
+    where: { id },
+    data: {
+      problem: body.problem !== undefined ? (body.problem as string | null) : report.problem,
+      plan: body.plan !== undefined ? (body.plan as string | null) : report.plan,
+    },
+    include: {
+      user: { select: { id: true, name: true, department: true } },
+      visitRecords: {
+        include: {
+          customer: { select: { id: true, companyName: true } },
+        },
+        orderBy: { visitOrder: "asc" },
+      },
+      comments: {
+        include: {
+          user: { select: { id: true, name: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  return successResponse({
+    report_id: updated.id,
+    report_date: formatDate(updated.reportDate),
+    status: updated.status,
+    problem: updated.problem,
+    plan: updated.plan,
+    user: {
+      user_id: updated.user.id,
+      name: updated.user.name,
+      department: updated.user.department,
+    },
+    visit_records: updated.visitRecords.map((vr) => ({
+      visit_id: vr.id,
+      customer: {
+        customer_id: vr.customer.id,
+        company_name: vr.customer.companyName,
+      },
+      visit_content: vr.visitContent,
+      visit_order: vr.visitOrder,
+    })),
+    comments: updated.comments.map((c) => ({
+      comment_id: c.id,
+      comment_text: c.commentText,
+      user: { user_id: c.user.id, name: c.user.name },
+      created_at: c.createdAt.toISOString(),
+    })),
+    created_at: updated.createdAt.toISOString(),
+    updated_at: updated.updatedAt.toISOString(),
   });
 }


### PR DESCRIPTION
## Summary

- `PUT /api/v1/reports/:report_id` ハンドラを実装（Issue #9）
- DRAFT の日報の `problem` / `plan` を更新し、更新後の詳細を返す
- SUBMITTED 日報の編集・他者の日報の編集は 403 で拒否
- `problem` / `plan` の 2000 文字超は 400 バリデーションエラー

## 実装内容

[src/app/api/v1/reports/[reportId]/route.ts](src/app/api/v1/reports/[reportId]/route.ts) に `PUT` ハンドラを追加。

1. SALES ロール以外は 403
2. 日報が存在しない場合は 404
3. 所有者チェック → 403
4. ステータスが `SUBMITTED` → 403「提出済みの日報は編集できません」
5. `problem` / `plan` の文字数バリデーション（2000 文字以内）→ 400
6. Prisma で更新し、GET と同形式のレスポンスを返す（200）

## 受け入れ条件チェック

- [x] AT-REPORT-004 #1: DRAFT の日報を正常に更新できる
- [x] AT-REPORT-004 #2 / UT-B-002 #2: SUBMITTED の日報を更新しようとすると 403
- [x] AT-REPORT-004 #3: 他者の日報を更新しようとすると 403
- [x] UT-V-001 #5 #6: problem / plan が 2000 文字超で 400

## Test plan

- [ ] SALES ユーザーで DRAFT 日報を PUT → 200、更新内容が反映されている
- [ ] SUBMITTED 日報を PUT → 403「提出済みの日報は編集できません」
- [ ] 他ユーザーの日報を PUT → 403
- [ ] MANAGER ロールで PUT → 403
- [ ] problem に 2001 文字を送信 → 400 VALIDATION_ERROR
- [ ] plan に 2001 文字を送信 → 400 VALIDATION_ERROR
- [ ] 存在しない report_id → 404

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)