### PR TITLE
[API] PATCH /api/v1/reports/:id/submit — 日報提出（F03）

### DIFF
--- a/src/app/api/v1/reports/[reportId]/submit/route.ts
+++ b/src/app/api/v1/reports/[reportId]/submit/route.ts
@@ -1,0 +1,46 @@
+import { conflictError, forbiddenError, notFoundError, successResponse } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["SALES"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const id = Number(reportId);
+  if (!Number.isInteger(id) || id <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  if (report.userId !== authUser.userId) {
+    return forbiddenError("この日報を提出する権限がありません");
+  }
+
+  if (report.status === "SUBMITTED") {
+    return conflictError("この日報は既に提出済みです");
+  }
+
+  const updated = await prisma.dailyReport.update({
+    where: { id },
+    data: { status: "SUBMITTED" },
+  });
+
+  return successResponse({
+    report_id: updated.id,
+    status: updated.status,
+    updated_at: updated.updatedAt.toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary

- `PATCH /api/v1/reports/:report_id/submit` エンドポイントを実装
- DRAFT → SUBMITTED へのステータス変更
- 所有者以外は 403、既に SUBMITTED なら 409 を返す

## Changes

- `src/app/api/v1/reports/[reportId]/submit/route.ts` を新規作成

## Acceptance Criteria

- [x] DRAFT → SUBMITTED に変更できる（AT-REPORT-005 #1）（UT-B-002 #1）
- [x] 既に SUBMITTED の場合 409 が返る（AT-REPORT-005 #2）
- [x] 他者の日報を提出しようとすると 403（AT-REPORT-005 #3）

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)