### PR TITLE
feat: Issue #11 - DELETE /api/v1/reports/:id 日報削除APIの実装

### DIFF
--- a/src/app/api/v1/reports/[reportId]/route.ts
+++ b/src/app/api/v1/reports/[reportId]/route.ts
@@ -1,4 +1,6 @@
 
+import { NextResponse } from "next/server";
+
 import {
   forbiddenError,
   notFoundError,
@@ -199,4 +201,38 @@ export async function PUT(
     created_at: updated.createdAt.toISOString(),
     updated_at: updated.updatedAt.toISOString(),
   });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["SALES"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const id = Number(reportId);
+  if (!Number.isInteger(id) || id <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  if (report.userId !== authUser.userId) {
+    return forbiddenError("この日報を削除する権限がありません");
+  }
+
+  if (report.status === "SUBMITTED") {
+    return forbiddenError("提出済みの日報は削除できません");
+  }
+
+  await prisma.dailyReport.delete({ where: { id } });
+
+  return new NextResponse(null, { status: 204 });
 }


### PR DESCRIPTION
## 概要

Closes #11

`DELETE /api/v1/reports/:report_id` エンドポイントを実装。DRAFT ステータスの日報を物理削除する。

## 変更内容

- `src/app/api/v1/reports/[reportId]/route.ts` に `DELETE` ハンドラを追加

## 実装ロジック

1. SALES ロールのみ許可（他ロールは 403）
2. reportId が不正な場合は 404
3. 日報が存在しない場合は 404
4. 他者の日報の場合は 403
5. SUBMITTED ステータスの日報は 403（「提出済みの日報は削除できません」）
6. `prisma.dailyReport.delete()` で物理削除（VisitRecord・Comment は Prisma の `onDelete: Cascade` により自動削除）
7. 204 No Content を返す

## 受け入れ条件チェック

- [x] DRAFT の日報を削除できる（204 が返る）
- [x] SUBMITTED の日報を削除しようとすると 403
- [x] 他者の日報を削除しようとすると 403
- [x] 削除後、GET で 404 になる（物理削除のため）

## Test plan

- [ ] `DELETE /api/v1/reports/:id` — DRAFT 日報: 204
- [ ] `DELETE /api/v1/reports/:id` — SUBMITTED 日報: 403
- [ ] `DELETE /api/v1/reports/:id` — 他者の日報: 403
- [ ] `DELETE /api/v1/reports/:id` — 存在しない ID: 404
- [ ] 削除後の `GET /api/v1/reports/:id`: 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)