### PR TITLE
feat: Issue #12 - POST /api/v1/reports/:id/visit-records 訪問記録追加API

### DIFF
--- a/src/app/api/v1/reports/[reportId]/visit-records/route.ts
+++ b/src/app/api/v1/reports/[reportId]/visit-records/route.ts
@@ -1,0 +1,111 @@
+import { forbiddenError, notFoundError, successResponse, validationError } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["SALES"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const id = Number(reportId);
+  if (!Number.isInteger(id) || id <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  if (report.userId !== authUser.userId) {
+    return forbiddenError("この日報を編集する権限がありません");
+  }
+
+  if (report.status === "SUBMITTED") {
+    return forbiddenError("提出済みの日報は編集できません");
+  }
+
+  const body = (await request.json()) as {
+    customer_id?: unknown;
+    visit_content?: unknown;
+    visit_order?: unknown;
+  };
+
+  const details: { field: string; message: string }[] = [];
+
+  if (body.customer_id === undefined || body.customer_id === null) {
+    details.push({ field: "customer_id", message: "顧客IDは必須です" });
+  } else if (
+    typeof body.customer_id !== "number" ||
+    !Number.isInteger(body.customer_id) ||
+    body.customer_id <= 0
+  ) {
+    details.push({ field: "customer_id", message: "顧客IDは正の整数で指定してください" });
+  }
+
+  if (body.visit_content === undefined || body.visit_content === null || body.visit_content === "") {
+    details.push({ field: "visit_content", message: "訪問内容は必須です" });
+  } else if (typeof body.visit_content !== "string") {
+    details.push({ field: "visit_content", message: "訪問内容は文字列で入力してください" });
+  } else if (body.visit_content.length > 1000) {
+    details.push({ field: "visit_content", message: "訪問内容は1000文字以内で入力してください" });
+  }
+
+  if (body.visit_order === undefined || body.visit_order === null) {
+    details.push({ field: "visit_order", message: "訪問順は必須です" });
+  } else if (
+    typeof body.visit_order !== "number" ||
+    !Number.isInteger(body.visit_order) ||
+    body.visit_order <= 0
+  ) {
+    details.push({ field: "visit_order", message: "訪問順は正の整数で指定してください" });
+  }
+
+  if (details.length > 0) {
+    return validationError("入力値が不正です", details);
+  }
+
+  const customer = await prisma.customer.findUnique({
+    where: { id: body.customer_id as number },
+  });
+
+  if (!customer || !customer.isActive) {
+    return validationError("入力値が不正です", [
+      { field: "customer_id", message: "指定された顧客が存在しません" },
+    ]);
+  }
+
+  const visitRecord = await prisma.visitRecord.create({
+    data: {
+      reportId: id,
+      customerId: body.customer_id as number,
+      visitContent: body.visit_content as string,
+      visitOrder: body.visit_order as number,
+    },
+    include: {
+      customer: { select: { id: true, companyName: true } },
+    },
+  });
+
+  return successResponse(
+    {
+      visit_id: visitRecord.id,
+      customer: {
+        customer_id: visitRecord.customer.id,
+        company_name: visitRecord.customer.companyName,
+      },
+      visit_content: visitRecord.visitContent,
+      visit_order: visitRecord.visitOrder,
+      created_at: visitRecord.createdAt.toISOString(),
+    },
+    201,
+  );
+}


### PR DESCRIPTION
## Summary

- `POST /api/v1/reports/:reportId/visit-records` エンドポイントを実装
- SALESロールのユーザーが自分の日報に訪問記録を1件追加できる

## 実装内容

**ファイル:** `src/app/api/v1/reports/[reportId]/visit-records/route.ts`

### 認可チェック
- SALESロール以外は403を返す
- 自分以外の日報には403を返す
- SUBMITTED状態の日報には403を返す（編集不可）

### バリデーション
- `customer_id`: 必須・正の整数
- `visit_content`: 必須・1000文字以内
- `visit_order`: 必須・正の整数
- 指定した顧客が存在しない or 論理削除済みの場合は400を返す

### レスポンス
- 正常時: 201 Created + 作成した訪問記録（顧客情報含む）
- 日報なし: 404
- 権限なし: 403
- バリデーションエラー: 400

## Test plan

- [ ] AT-VISIT-001 #1: 正常追加 → 201
- [ ] AT-VISIT-001 #2: SUBMITTED 日報への追加 → 403
- [ ] AT-VISIT-001 #3: 存在しない customer_id → 400
- [ ] AT-VISIT-001 #4: 他者の日報への追加 → 403

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/claude-code)