### PR TITLE
feat: Issue #15 - PATCH /api/v1/reports/:id/visit-records/reorder 訪問記録並び替えAPI

### DIFF
--- a/src/app/api/v1/reports/[reportId]/visit-records/reorder/route.ts
+++ b/src/app/api/v1/reports/[reportId]/visit-records/reorder/route.ts
@@ -1,0 +1,105 @@
+import { forbiddenError, notFoundError, successResponse, validationError } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["SALES"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const reportIdNum = Number(reportId);
+
+  if (!Number.isInteger(reportIdNum) || reportIdNum <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportIdNum },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  if (report.userId !== authUser.userId) {
+    return forbiddenError("この日報を編集する権限がありません");
+  }
+
+  if (report.status === "SUBMITTED") {
+    return forbiddenError("提出済みの日報は編集できません");
+  }
+
+  const body = (await request.json()) as { orders?: unknown };
+
+  if (!Array.isArray(body.orders) || body.orders.length === 0) {
+    return validationError("入力値が不正です", [
+      { field: "orders", message: "ordersは1件以上の配列で指定してください" },
+    ]);
+  }
+
+  const details: { field: string; message: string }[] = [];
+
+  for (let i = 0; i < body.orders.length; i++) {
+    const item = body.orders[i] as Record<string, unknown>;
+
+    if (
+      typeof item.visit_id !== "number" ||
+      !Number.isInteger(item.visit_id) ||
+      item.visit_id <= 0
+    ) {
+      details.push({ field: `orders[${i}].visit_id`, message: "visit_idは正の整数で指定してください" });
+    }
+
+    if (
+      typeof item.visit_order !== "number" ||
+      !Number.isInteger(item.visit_order) ||
+      item.visit_order <= 0
+    ) {
+      details.push({ field: `orders[${i}].visit_order`, message: "visit_orderは正の整数で指定してください" });
+    }
+  }
+
+  if (details.length > 0) {
+    return validationError("入力値が不正です", details);
+  }
+
+  type OrderItem = { visit_id: number; visit_order: number };
+  const orders = body.orders as OrderItem[];
+  const visitIds = orders.map((o) => o.visit_id);
+
+  const existingRecords = await prisma.visitRecord.findMany({
+    where: { id: { in: visitIds } },
+    select: { id: true, reportId: true },
+  });
+
+  const existingIds = new Set(existingRecords.map((r) => r.id));
+
+  for (const visitId of visitIds) {
+    if (!existingIds.has(visitId)) {
+      return notFoundError(`visit_id: ${visitId} の訪問記録が見つかりません`);
+    }
+  }
+
+  const wrongReport = existingRecords.find((r) => r.reportId !== reportIdNum);
+  if (wrongReport) {
+    return validationError("入力値が不正です", [
+      { field: "orders", message: "別の日報に属するvisit_idが含まれています" },
+    ]);
+  }
+
+  await prisma.$transaction(
+    orders.map((o) =>
+      prisma.visitRecord.update({
+        where: { id: o.visit_id },
+        data: { visitOrder: o.visit_order },
+      }),
+    ),
+  );
+
+  return successResponse(null);
+}


### PR DESCRIPTION
## 概要

- `PATCH /api/v1/reports/:report_id/visit-records/reorder` エンドポイントを実装（Issue #15）
- 訪問記録の `visit_order` をリクエストボディの `orders` 配列に従いトランザクションで一括更新する

## 実装ファイル

`src/app/api/v1/reports/[reportId]/visit-records/reorder/route.ts`

## 主な処理フロー

1. SALES ロール認証チェック → 403
2. 日報取得 → 404（存在しない場合）
3. 所有者チェック → 403（他者の日報）
4. ステータスチェック: `SUBMITTED` → 403
5. `orders` バリデーション（配列・各要素の型チェック）→ 400
6. `visit_id` の存在確認 → 404（存在しない場合）
7. `visit_id` が当該日報に属するか確認 → 400（別日報のIDが含まれる場合）
8. トランザクションで全件 `visit_order` を一括更新
9. 200: `{ data: null, message: "success" }`

## ルーティング

Next.js では静的セグメント（`reorder`）が動的セグメント（`[visitId]`）より優先されるため、`/visit-records/reorder` と `/visit-records/:visitId` は競合しない。

## 受け入れ条件

- [x] 正常な並び替えが反映される（AT-VISIT-002 #1）（UT-B-003 #1）
- [x] 別日報の visit_id を含むと 400（AT-VISIT-002 #2）
- [x] 存在しない visit_id で 404（UT-B-003 #2）
- [x] 並び替え後、GET /reports/:id で指定順に返る

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)