### PR TITLE
feat: Issue #16 - POST /api/v1/reports/:id/comments コメント投稿API

### DIFF
--- a/src/app/api/v1/reports/[reportId]/comments/route.ts
+++ b/src/app/api/v1/reports/[reportId]/comments/route.ts
@@ -1,0 +1,70 @@
+import { forbiddenError, notFoundError, successResponse, validationError } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string }> },
+) {
+  const authUser = requireRole(request, ["MANAGER"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId } = await params;
+  const reportIdNum = Number(reportId);
+  if (!Number.isInteger(reportIdNum) || reportIdNum <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportIdNum },
+  });
+
+  if (!report) {
+    return notFoundError("日報が見つかりません");
+  }
+
+  const body = (await request.json()) as { comment_text?: unknown };
+
+  if (
+    body.comment_text === undefined ||
+    body.comment_text === null ||
+    body.comment_text === ""
+  ) {
+    return validationError("入力値が不正です", [
+      { field: "comment_text", message: "コメント本文は必須です" },
+    ]);
+  }
+
+  if (typeof body.comment_text !== "string") {
+    return validationError("入力値が不正です", [
+      { field: "comment_text", message: "コメント本文は文字列で入力してください" },
+    ]);
+  }
+
+  const comment = await prisma.comment.create({
+    data: {
+      reportId: reportIdNum,
+      userId: authUser.userId,
+      commentText: body.comment_text,
+    },
+    include: {
+      user: { select: { id: true, name: true } },
+    },
+  });
+
+  return successResponse(
+    {
+      comment_id: comment.id,
+      comment_text: comment.commentText,
+      user: {
+        user_id: comment.user.id,
+        name: comment.user.name,
+      },
+      created_at: comment.createdAt.toISOString(),
+      updated_at: comment.updatedAt.toISOString(),
+    },
+    201,
+  );
+}


### PR DESCRIPTION
## 概要

- `POST /api/v1/reports/:report_id/comments` エンドポイントを実装
- MANAGERロールのみコメント投稿可能（SALESは403）

## 実装内容

- `src/app/api/v1/reports/[reportId]/comments/route.ts` を新規作成
- ロール検証: MANAGERのみ許可（それ以外は403）
- 日報の存在チェック（404）
- `comment_text` バリデーション: 必須・空文字不可（400）
- Commentレコード作成 → 201レスポンス

## 受け入れ条件

- [x] MANAGER が正常にコメントを投稿できる（AT-COMMENT-001 #1）
- [x] SALES がアクセスすると 403（AT-COMMENT-001 #2）
- [x] 空文字で 400（AT-COMMENT-001 #3）
- [x] 存在しない report_id で 404（AT-COMMENT-001 #4）

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)