### PR TITLE
[API] GET /api/v1/customers — 顧客一覧取得（F13）

### DIFF
--- a/src/app/api/v1/customers/route.ts
+++ b/src/app/api/v1/customers/route.ts
@@ -1,0 +1,64 @@
+
+import { forbiddenError, successResponse } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const authUser = requireRole(request, ["SALES", "MANAGER", "ADMIN"]);
+  if (!authUser) return forbiddenError();
+
+  const { searchParams } = request.nextUrl;
+  const q = searchParams.get("q") ?? undefined;
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+  const perPage = Math.max(
+    1,
+    Number(searchParams.get("per_page") ?? "50") || 50,
+  );
+
+  const where = {
+    isActive: true,
+    ...(q
+      ? {
+          OR: [
+            { companyName: { contains: q } },
+            { contactPerson: { contains: q } },
+          ],
+        }
+      : {}),
+  };
+
+  const [total, customers] = await Promise.all([
+    prisma.customer.count({ where }),
+    prisma.customer.findMany({
+      where,
+      orderBy: { companyName: "asc" },
+      skip: (page - 1) * perPage,
+      take: perPage,
+      select: {
+        id: true,
+        companyName: true,
+        contactPerson: true,
+        phone: true,
+        address: true,
+      },
+    }),
+  ]);
+
+  return successResponse({
+    customers: customers.map((c) => ({
+      customer_id: c.id,
+      company_name: c.companyName,
+      contact_person: c.contactPerson,
+      phone: c.phone,
+      address: c.address,
+    })),
+    pagination: {
+      total,
+      page,
+      per_page: perPage,
+      total_pages: Math.ceil(total / perPage),
+    },
+  });
+}

--- a/src/app/api/v1/reports/[reportId]/visit-records/[visitId]/route.ts
+++ b/src/app/api/v1/reports/[reportId]/visit-records/[visitId]/route.ts
@@ -1,8 +1,9 @@
+import { NextResponse } from "next/server";
+
 import { forbiddenError, notFoundError, successResponse, validationError } from "@/lib/api-response";
 import { prisma } from "@/lib/prisma";
 import { requireRole } from "@/lib/require-role";
 
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export async function PUT(


### PR DESCRIPTION
## Summary

- `GET /api/v1/customers` エンドポイントを実装（Issue #19）
- SALES / MANAGER / ADMIN 全ロールでアクセス可能
- `is_active = true` の顧客のみ返す（論理削除済みを除外）
- `?q=` クエリで `company_name` / `contact_person` の部分一致検索
- `page` / `per_page` によるページネーション（デフォルト: page=1, per_page=50）

## Test plan

- [ ] SALES / MANAGER / ADMIN 全ロールで 200 が返ること（AT-CUSTOMER-001 #1）
- [ ] `?q=株式会社` で一致する顧客のみ返ること（AT-CUSTOMER-001 #2）
- [ ] `is_active=false` の顧客が結果に含まれないこと（AT-CUSTOMER-001 #3）
- [ ] Authorization ヘッダーなしで 401 が返ること

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/claude-code)