### PR TITLE
[API] DELETE /api/v1/reports/:id/comments/:cid — コメント削除（F12）

### DIFF
--- a/src/app/api/v1/reports/[reportId]/comments/[commentId]/route.ts
+++ b/src/app/api/v1/reports/[reportId]/comments/[commentId]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+
+
+import { forbiddenError, notFoundError, successResponse, validationError } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { NextRequest } from "next/server";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string; commentId: string }> },
+) {
+  const authUser = requireRole(request, ["MANAGER"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId, commentId } = await params;
+  const reportIdNum = Number(reportId);
+  const commentIdNum = Number(commentId);
+
+  if (!Number.isInteger(reportIdNum) || reportIdNum <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+  if (!Number.isInteger(commentIdNum) || commentIdNum <= 0) {
+    return notFoundError("コメントが見つかりません");
+  }
+
+  // 1. コメントの取得（日報への所属も確認）
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentIdNum },
+    include: { user: { select: { id: true, name: true } } },
+  });
+
+  if (!comment || comment.reportId !== reportIdNum) {
+    return notFoundError("コメントが見つかりません");
+  }
+
+  // 2. 投稿者チェック: 自分以外 → 403
+  if (comment.userId !== authUser.userId) {
+    return forbiddenError("他のユーザーのコメントは編集できません");
+  }
+
+  // 3. バリデーション
+  const body = (await request.json()) as { comment_text?: unknown };
+
+  if (
+    body.comment_text === undefined ||
+    body.comment_text === null ||
+    body.comment_text === ""
+  ) {
+    return validationError("入力値が不正です", [
+      { field: "comment_text", message: "コメント本文は必須です" },
+    ]);
+  }
+
+  if (typeof body.comment_text !== "string") {
+    return validationError("入力値が不正です", [
+      { field: "comment_text", message: "コメント本文は文字列で入力してください" },
+    ]);
+  }
+
+  // 4. コメントを更新
+  const updated = await prisma.comment.update({
+    where: { id: commentIdNum },
+    data: { commentText: body.comment_text },
+    include: { user: { select: { id: true, name: true } } },
+  });
+
+  // 5. 200: 更新後のコメントを返す
+  return successResponse({
+    comment_id: updated.id,
+    comment_text: updated.commentText,
+    user: {
+      user_id: updated.user.id,
+      name: updated.user.name,
+    },
+    created_at: updated.createdAt.toISOString(),
+    updated_at: updated.updatedAt.toISOString(),
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ reportId: string; commentId: string }> },
+) {
+  const authUser = requireRole(request, ["MANAGER"]);
+  if (!authUser) return forbiddenError();
+
+  const { reportId, commentId } = await params;
+  const reportIdNum = Number(reportId);
+  const commentIdNum = Number(commentId);
+
+  if (!Number.isInteger(reportIdNum) || reportIdNum <= 0) {
+    return notFoundError("日報が見つかりません");
+  }
+  if (!Number.isInteger(commentIdNum) || commentIdNum <= 0) {
+    return notFoundError("コメントが見つかりません");
+  }
+
+  // 1. コメントの取得（日報への所属も確認）
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentIdNum },
+  });
+
+  if (!comment || comment.reportId !== reportIdNum) {
+    return notFoundError("コメントが見つかりません");
+  }
+
+  // 2. 投稿者チェック: 自分以外 → 403
+  if (comment.userId !== authUser.userId) {
+    return forbiddenError("他のユーザーのコメントは削除できません");
+  }
+
+  // 3. コメントを削除
+  await prisma.comment.delete({ where: { id: commentIdNum } });
+
+  // 4. 204 No Content
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/v1/reports/[reportId]/visit-records/[visitId]/route.ts
+++ b/src/app/api/v1/reports/[reportId]/visit-records/[visitId]/route.ts
@@ -1,8 +1,9 @@
+import { NextResponse } from "next/server";
+
 import { forbiddenError, notFoundError, successResponse, validationError } from "@/lib/api-response";
 import { prisma } from "@/lib/prisma";
 import { requireRole } from "@/lib/require-role";
 
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export async function PUT(


### PR DESCRIPTION
## 概要

Issue #18 の実装: `DELETE /api/v1/reports/:id/comments/:cid`

自分が投稿したコメントを削除するエンドポイントです。

## 実装内容

`src/app/api/v1/reports/[reportId]/comments/[commentId]/route.ts` に `DELETE` ハンドラを追加:

1. MANAGERロールのみアクセス可能（それ以外は 403）
2. `reportId` / `commentId` のバリデーション（不正値は 404）
3. コメントを取得し、指定日報への所属を確認（404）
4. 投稿者チェック: 自分以外のコメントは削除不可（403）
5. コメントを削除して 204 No Content を返す

## 受け入れ条件

- [x] 自分のコメントを削除できる（AT-COMMENT-002 #3）
- [x] 他者のコメントを削除しようとすると 403（AT-COMMENT-002 #4）

## Test plan

- [ ] `DELETE /api/v1/reports/:id/comments/:cid` — 自分のコメント → 204
- [ ] 他者のコメントを削除 → 403 FORBIDDEN
- [ ] 存在しないコメント → 404 NOT_FOUND
- [ ] MANAGERロール以外でアクセス → 403 FORBIDDEN

## 依存

- Issue #17 (#feature/issue-17-update-comment) の PUT ハンドラと同一ファイルに実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)