### PR TITLE
feat: GET /api/v1/users — ユーザー一覧取得 (Issue #23)

### DIFF
--- a/src/app/api/v1/users/route.ts
+++ b/src/app/api/v1/users/route.ts
@@ -1,0 +1,54 @@
+import { forbiddenError, successResponse } from "@/lib/api-response";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/require-role";
+
+import type { Role } from "@/types";
+import type { NextRequest } from "next/server";
+
+const VALID_ROLES: Role[] = ["SALES", "MANAGER", "ADMIN"];
+
+export async function GET(request: NextRequest) {
+  // 1. ロール検証: ADMIN のみ許可
+  const authUser = requireRole(request, ["ADMIN"]);
+  if (!authUser) return forbiddenError();
+
+  const { searchParams } = request.nextUrl;
+  const roleParam = searchParams.get("role");
+  const isActiveParam = searchParams.get("is_active");
+
+  // 2. フィルター構築
+  const where: { role?: Role; isActive: boolean } = {
+    isActive: isActiveParam === "false" ? false : true,
+  };
+
+  if (roleParam !== null && VALID_ROLES.includes(roleParam as Role)) {
+    where.role = roleParam as Role;
+  }
+
+  // 3. ユーザー一覧取得（password_hash は含めない）
+  const users = await prisma.user.findMany({
+    where,
+    orderBy: { id: "asc" },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      department: true,
+      isActive: true,
+      createdAt: true,
+    },
+  });
+
+  return successResponse({
+    users: users.map((u) => ({
+      user_id: u.id,
+      name: u.name,
+      email: u.email,
+      role: u.role,
+      department: u.department,
+      is_active: u.isActive,
+      created_at: u.createdAt.toISOString(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary

- `GET /api/v1/users` エンドポイントを実装
- ADMIN ロール以外は 403 を返す
- `role` クエリパラメータ（SALES / MANAGER / ADMIN）でフィルタリング
- `is_active` クエリパラメータでフィルタリング（デフォルト: true）
- レスポンスに `password_hash` を含めない

## 受け入れ条件

- [x] ADMIN が全ユーザーを取得できる
- [x] role で絞り込みできる
- [x] is_active=false で無効ユーザーも取得できる
- [x] SALES がアクセスすると 403
- [x] レスポンスに password_hash が含まれない

## Test plan

- [ ] ADMIN トークンで `GET /api/v1/users` → 200、users 配列が返る
- [ ] `?role=SALES` → SALES のみ絞り込まれる
- [ ] `?is_active=false` → 無効ユーザーが含まれる
- [ ] SALES トークンでアクセス → 403
- [ ] MANAGER トークンでアクセス → 403
- [ ] レスポンスに `password_hash` フィールドが存在しない

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)