### PR TITLE
feat: SCR-07/08 ユーザーマスター一覧・登録・編集画面を実装 (Issue #34)

### DIFF
--- a/src/app/(auth)/master/users/[id]/page.tsx
+++ b/src/app/(auth)/master/users/[id]/page.tsx
@@ -1,8 +1,322 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuth } from "@/contexts/AuthContext";
+
+import type { Role, User } from "@/types";
+
+interface FieldErrors {
+  name?: string;
+  email?: string;
+  role?: string;
+  department?: string;
+}
+
+interface UsersResponse {
+  data: { users: User[] };
+  message: string;
+}
+
+interface ErrorResponse {
+  error: { code: string; message: string; details?: { field: string; message: string }[] };
+}
+
+function EditUserContent() {
+  const router = useRouter();
+  const params = useParams();
+  const { token, user: authUser } = useAuth();
+  const userId = Number(params.id);
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Role | "">("");
+  const [department, setDepartment] = useState("");
+  const [isActive, setIsActive] = useState(true);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [apiError, setApiError] = useState("");
+  const [loadError, setLoadError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchUser = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError("");
+    try {
+      // 有効・無効の両方を取得して該当ユーザーを探す
+      const [activeRes, inactiveRes] = await Promise.all([
+        fetch("/api/v1/users", {
+          headers: { Authorization: `Bearer ${token ?? ""}` },
+        }),
+        fetch("/api/v1/users?is_active=false", {
+          headers: { Authorization: `Bearer ${token ?? ""}` },
+        }),
+      ]);
+
+      if (!activeRes.ok || !inactiveRes.ok) {
+        setLoadError("ユーザー情報の取得に失敗しました");
+        return;
+      }
+
+      const [activeJson, inactiveJson] = (await Promise.all([
+        activeRes.json(),
+        inactiveRes.json(),
+      ])) as [UsersResponse, UsersResponse];
+
+      const allUsers = [...activeJson.data.users, ...inactiveJson.data.users];
+      const found = allUsers.find((u) => u.user_id === userId);
+
+      if (!found) {
+        setLoadError("ユーザーが見つかりません");
+        return;
+      }
+
+      setName(found.name);
+      setEmail(found.email);
+      setRole(found.role);
+      setDepartment(found.department ?? "");
+      setIsActive(found.is_active);
+    } catch {
+      setLoadError("通信エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, userId]);
+
+  useEffect(() => {
+    void fetchUser();
+  }, [fetchUser]);
+
+  function validate(): boolean {
+    const next: FieldErrors = {};
+
+    if (!name.trim()) {
+      next.name = "氏名は必須です";
+    } else if (name.length > 100) {
+      next.name = "氏名は100文字以内で入力してください";
+    }
+
+    const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!email.trim()) {
+      next.email = "メールアドレスは必須です";
+    } else if (!EMAIL_REGEX.test(email)) {
+      next.email = "メールアドレスの形式で入力してください";
+    }
+
+    if (!role) {
+      next.role = "ロールは必須です";
+    }
+
+    if (department.length > 100) {
+      next.department = "部署名は100文字以内で入力してください";
+    }
+
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setApiError("");
+
+    if (!validate()) return;
+
+    // 自分自身を無効化しようとしている場合はクライアント側でも警告
+    if (authUser?.user_id === userId && !isActive) {
+      setApiError("自分自身を無効化することはできません");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/v1/users/${userId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token ?? ""}`,
+        },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          role,
+          department: department.trim() || undefined,
+          is_active: isActive,
+        }),
+      });
+
+      if (res.ok) {
+        router.push("/master/users");
+        return;
+      }
+
+      const json = (await res.json()) as ErrorResponse;
+      if (res.status === 409) {
+        setErrors({ email: json.error.message });
+      } else if (res.status === 400 && json.error.details) {
+        const next: FieldErrors = {};
+        for (const d of json.error.details) {
+          (next as Record<string, string>)[d.field] = d.message;
+        }
+        setErrors(next);
+      } else {
+        setApiError(json.error?.message ?? "保存に失敗しました");
+      }
+    } catch {
+      setApiError("通信エラーが発生しました");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">読み込み中...</p>;
+  }
+
+  if (loadError) {
+    return <p className="text-sm text-destructive">{loadError}</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">ユーザー編集</h1>
+
+      <form onSubmit={handleSubmit} noValidate className="max-w-lg space-y-4">
+        {/* 氏名 */}
+        <div className="space-y-1">
+          <label htmlFor="name" className="text-sm font-medium">
+            氏名 <span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={submitting}
+          />
+          {errors.name && (
+            <p className="text-sm text-destructive">{errors.name}</p>
+          )}
+        </div>
+
+        {/* メールアドレス */}
+        <div className="space-y-1">
+          <label htmlFor="email" className="text-sm font-medium">
+            メールアドレス <span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="off"
+            disabled={submitting}
+          />
+          {errors.email && (
+            <p className="text-sm text-destructive">{errors.email}</p>
+          )}
+        </div>
+
+        {/* ロール */}
+        <div className="space-y-1">
+          <label htmlFor="role" className="text-sm font-medium">
+            ロール <span className="text-destructive">*</span>
+          </label>
+          <Select
+            value={role}
+            onValueChange={(v) => setRole(v as Role)}
+            disabled={submitting}
+          >
+            <SelectTrigger id="role">
+              <SelectValue placeholder="選択してください" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="SALES">SALES</SelectItem>
+              <SelectItem value="MANAGER">MANAGER</SelectItem>
+              <SelectItem value="ADMIN">ADMIN</SelectItem>
+            </SelectContent>
+          </Select>
+          {errors.role && (
+            <p className="text-sm text-destructive">{errors.role}</p>
+          )}
+        </div>
+
+        {/* 部署名 */}
+        <div className="space-y-1">
+          <label htmlFor="department" className="text-sm font-medium">
+            部署名
+          </label>
+          <Input
+            id="department"
+            value={department}
+            onChange={(e) => setDepartment(e.target.value)}
+            disabled={submitting}
+          />
+          {errors.department && (
+            <p className="text-sm text-destructive">{errors.department}</p>
+          )}
+        </div>
+
+        {/* 有効フラグ */}
+        <div className="flex items-center gap-3">
+          <label htmlFor="is-active" className="text-sm font-medium">
+            有効フラグ
+          </label>
+          <button
+            id="is-active"
+            type="button"
+            role="switch"
+            aria-checked={isActive}
+            disabled={submitting}
+            onClick={() => setIsActive((prev) => !prev)}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+              isActive ? "bg-primary" : "bg-input"
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
+                isActive ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+          <span className="text-sm text-muted-foreground">
+            {isActive ? "有効" : "無効"}
+          </span>
+        </div>
+
+        {apiError && <p className="text-sm text-destructive">{apiError}</p>}
+
+        <div className="flex gap-3 pt-2">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? "保存中..." : "保存"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={submitting}
+            onClick={() => router.push("/master/users")}
+          >
+            キャンセル
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
 export default function EditUserPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">ユーザー編集</h1>
-      <p className="mt-2 text-muted-foreground">Issue #34 で実装予定</p>
-    </div>
+    <AuthGuard allowedRoles={["ADMIN"]}>
+      <EditUserContent />
+    </AuthGuard>
   );
 }

--- a/src/app/(auth)/master/users/new/page.tsx
+++ b/src/app/(auth)/master/users/new/page.tsx
@@ -1,8 +1,251 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuth } from "@/contexts/AuthContext";
+
+import type { Role } from "@/types";
+
+interface FieldErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  role?: string;
+  department?: string;
+}
+
+interface ErrorResponse {
+  error: { code: string; message: string; details?: { field: string; message: string }[] };
+}
+
+function NewUserContent() {
+  const router = useRouter();
+  const { token } = useAuth();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [role, setRole] = useState<Role | "">("");
+  const [department, setDepartment] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [apiError, setApiError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  function validate(): boolean {
+    const next: FieldErrors = {};
+
+    if (!name.trim()) {
+      next.name = "氏名は必須です";
+    } else if (name.length > 100) {
+      next.name = "氏名は100文字以内で入力してください";
+    }
+
+    const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!email.trim()) {
+      next.email = "メールアドレスは必須です";
+    } else if (!EMAIL_REGEX.test(email)) {
+      next.email = "メールアドレスの形式で入力してください";
+    }
+
+    if (!password) {
+      next.password = "パスワードは必須です";
+    } else if (password.length < 8) {
+      next.password = "パスワードは8文字以上で入力してください";
+    } else if (!/[a-zA-Z]/.test(password) || !/[0-9]/.test(password)) {
+      next.password = "パスワードは英字と数字を混在させてください";
+    }
+
+    if (!role) {
+      next.role = "ロールは必須です";
+    }
+
+    if (department.length > 100) {
+      next.department = "部署名は100文字以内で入力してください";
+    }
+
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setApiError("");
+
+    if (!validate()) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token ?? ""}`,
+        },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          password,
+          role,
+          department: department.trim() || undefined,
+        }),
+      });
+
+      if (res.ok) {
+        router.push("/master/users");
+        return;
+      }
+
+      const json = (await res.json()) as ErrorResponse;
+      if (res.status === 409) {
+        setErrors({ email: json.error.message });
+      } else if (res.status === 400 && json.error.details) {
+        const next: FieldErrors = {};
+        for (const d of json.error.details) {
+          (next as Record<string, string>)[d.field] = d.message;
+        }
+        setErrors(next);
+      } else {
+        setApiError(json.error?.message ?? "保存に失敗しました");
+      }
+    } catch {
+      setApiError("通信エラーが発生しました");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">ユーザー登録</h1>
+
+      <form onSubmit={handleSubmit} noValidate className="max-w-lg space-y-4">
+        {/* 氏名 */}
+        <div className="space-y-1">
+          <label htmlFor="name" className="text-sm font-medium">
+            氏名 <span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={submitting}
+          />
+          {errors.name && (
+            <p className="text-sm text-destructive">{errors.name}</p>
+          )}
+        </div>
+
+        {/* メールアドレス */}
+        <div className="space-y-1">
+          <label htmlFor="email" className="text-sm font-medium">
+            メールアドレス <span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="off"
+            disabled={submitting}
+          />
+          {errors.email && (
+            <p className="text-sm text-destructive">{errors.email}</p>
+          )}
+        </div>
+
+        {/* パスワード */}
+        <div className="space-y-1">
+          <label htmlFor="password" className="text-sm font-medium">
+            パスワード <span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            disabled={submitting}
+          />
+          {errors.password && (
+            <p className="text-sm text-destructive">{errors.password}</p>
+          )}
+        </div>
+
+        {/* ロール */}
+        <div className="space-y-1">
+          <label htmlFor="role" className="text-sm font-medium">
+            ロール <span className="text-destructive">*</span>
+          </label>
+          <Select
+            value={role}
+            onValueChange={(v) => setRole(v as Role)}
+            disabled={submitting}
+          >
+            <SelectTrigger id="role">
+              <SelectValue placeholder="選択してください" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="SALES">SALES</SelectItem>
+              <SelectItem value="MANAGER">MANAGER</SelectItem>
+              <SelectItem value="ADMIN">ADMIN</SelectItem>
+            </SelectContent>
+          </Select>
+          {errors.role && (
+            <p className="text-sm text-destructive">{errors.role}</p>
+          )}
+        </div>
+
+        {/* 部署名 */}
+        <div className="space-y-1">
+          <label htmlFor="department" className="text-sm font-medium">
+            部署名
+          </label>
+          <Input
+            id="department"
+            value={department}
+            onChange={(e) => setDepartment(e.target.value)}
+            disabled={submitting}
+          />
+          {errors.department && (
+            <p className="text-sm text-destructive">{errors.department}</p>
+          )}
+        </div>
+
+        {apiError && <p className="text-sm text-destructive">{apiError}</p>}
+
+        <div className="flex gap-3 pt-2">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? "保存中..." : "保存"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={submitting}
+            onClick={() => router.push("/master/users")}
+          >
+            キャンセル
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
 export default function NewUserPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">ユーザー登録</h1>
-      <p className="mt-2 text-muted-foreground">Issue #34 で実装予定</p>
-    </div>
+    <AuthGuard allowedRoles={["ADMIN"]}>
+      <NewUserContent />
+    </AuthGuard>
   );
 }

--- a/src/app/(auth)/master/users/page.tsx
+++ b/src/app/(auth)/master/users/page.tsx
@@ -1,8 +1,152 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useAuth } from "@/contexts/AuthContext";
+
+import type { User } from "@/types";
+
+interface UsersResponse {
+  data: { users: User[] };
+  message: string;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  SALES: "SALES",
+  MANAGER: "MANAGER",
+  ADMIN: "ADMIN",
+};
+
+function UsersContent() {
+  const router = useRouter();
+  const { token } = useAuth();
+  const [users, setUsers] = useState<User[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchUsers = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+    try {
+      const [activeRes, inactiveRes] = await Promise.all([
+        fetch("/api/v1/users", {
+          headers: { Authorization: `Bearer ${token ?? ""}` },
+        }),
+        fetch("/api/v1/users?is_active=false", {
+          headers: { Authorization: `Bearer ${token ?? ""}` },
+        }),
+      ]);
+
+      if (!activeRes.ok || !inactiveRes.ok) {
+        setError("ユーザー一覧の取得に失敗しました");
+        return;
+      }
+
+      const [activeJson, inactiveJson] = (await Promise.all([
+        activeRes.json(),
+        inactiveRes.json(),
+      ])) as [UsersResponse, UsersResponse];
+
+      const combined = [...activeJson.data.users, ...inactiveJson.data.users];
+      // user_id で重複除去して id 昇順に並べる
+      const unique = Array.from(
+        new Map(combined.map((u) => [u.user_id, u])).values(),
+      ).sort((a, b) => a.user_id - b.user_id);
+
+      setUsers(unique);
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void fetchUsers();
+  }, [fetchUsers]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ユーザーマスター</h1>
+        <Button onClick={() => router.push("/master/users/new")}>
+          + 新規登録
+        </Button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>氏名</TableHead>
+              <TableHead>メールアドレス</TableHead>
+              <TableHead>ロール</TableHead>
+              <TableHead>状態</TableHead>
+              <TableHead>操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="text-center text-muted-foreground"
+                >
+                  ユーザーが見つかりません
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((user) => (
+                <TableRow key={user.user_id}>
+                  <TableCell className="font-medium">{user.name}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>{ROLE_LABELS[user.role] ?? user.role}</TableCell>
+                  <TableCell>
+                    <Badge variant={user.is_active ? "default" : "secondary"}>
+                      {user.is_active ? "有効" : "無効"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        router.push(`/master/users/${user.user_id}`)
+                      }
+                    >
+                      編集
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
 export default function UsersPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">ユーザーマスター</h1>
-      <p className="mt-2 text-muted-foreground">Issue #34 で実装予定</p>
-    </div>
+    <AuthGuard allowedRoles={["ADMIN"]}>
+      <UsersContent />
+    </AuthGuard>
   );
 }


### PR DESCRIPTION
## Summary

- SCR-07: `/master/users` — ユーザー一覧テーブル（氏名・メール・ロール・状態バッジ・編集ボタン）を実装
- SCR-08 新規: `/master/users/new` — ユーザー登録フォーム（氏名・メール・パスワード・ロール・部署名）を実装
- SCR-08 編集: `/master/users/[id]` — ユーザー編集フォーム（パスワード非表示・有効フラグ toggle）を実装
- 全画面に `AuthGuard allowedRoles={["ADMIN"]}` を適用し、ADMIN 以外はアクセス拒否
- 自分自身を無効化しようとした場合のエラーメッセージをクライアント側でも表示

## Test plan

- [ ] ADMIN でログインし `/master/users` に一覧が表示される
- [ ] 有効・無効ユーザーが両方表示される（有効バッジ / 無効バッジ）
- [ ] `[+ 新規登録]` → 登録フォームに遷移し、POST 成功後に一覧へ戻る
- [ ] メールアドレス重複時に「このメールアドレスは既に使用されています」が表示される
- [ ] `[編集]` → 編集フォームに既存データが反映され、PUT 成功後に一覧へ戻る
- [ ] 有効フラグ toggle でON/OFF が切り替わる
- [ ] 自分自身を無効化しようとすると「自分自身を無効化することはできません」が表示される
- [ ] SALES / MANAGER で `/master/users` にアクセスすると unauthorized にリダイレクトされる

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)